### PR TITLE
Add ephemeral-storage requests and limits to django-postgresql-namespace

### DIFF
--- a/openshift/templates/django-postgresql-namespace.json
+++ b/openshift/templates/django-postgresql-namespace.json
@@ -274,8 +274,12 @@
                   }
                 ],
                 "resources": {
+                  "requests": {
+                    "ephemeral-storage": "${EPHEMERAL_REQUEST}"
+                  },
                   "limits": {
-                    "memory": "${MEMORY_LIMIT}"
+                    "memory": "${MEMORY_LIMIT}",
+                    "ephemeral-storage": "${EPHEMERAL_LIMIT}"
                   }
                 }
               }
@@ -440,6 +444,20 @@
       "required": true,
       "description": "Maximum amount of memory the Django container can use.",
       "value": "256Mi"
+    },
+    {
+      "name": "EPHEMERAL_REQUEST",
+      "displayName": "Ephemeral Storage Request",
+      "required": true,
+      "description": "Maximum amount of Ephemeral Storage the Django container can use.",
+      "value": "500Mi"
+    },
+    {
+      "name": "EPHEMERAL_LIMIT",
+      "displayName": "Ephemeral Storage Limit",
+      "required": true,
+      "description": "Maximum amount of Ephemeral Storage the Django container can use.",
+      "value": "1Gi"
     },
     {
       "name": "MEMORY_POSTGRESQL_LIMIT",


### PR DESCRIPTION
On the 4.3 nightly (on ppc64le) the app build was failing due to
requesting ephemeral storage but not having a limit, despite there being
plenty on the node.

This change add a couple of parameters to the template with "sane"
default values.